### PR TITLE
Send message templates to Seq

### DIFF
--- a/src/LogMagic/Tokenisation/FormattedString.cs
+++ b/src/LogMagic/Tokenisation/FormattedString.cs
@@ -59,6 +59,11 @@ namespace LogMagic.Tokenisation
       }
 
       /// <summary>
+      /// The underlying format string.
+      /// </summary>
+      public string Template => _format ?? string.Empty;
+
+      /// <summary>
       /// Formats the token as a string
       /// </summary>
       public string Format(Token token, object value = null)

--- a/src/LogMagic/Writers/SeqWriter.cs
+++ b/src/LogMagic/Writers/SeqWriter.cs
@@ -77,7 +77,7 @@ namespace LogMagic.Writers
             {
                Timestamp = new DateTimeOffset(e.EventTime),
                Level = e.Severity.ToString(),
-               MessageTemplate = e.FormattedMessage,
+               MessageTemplate = e.Message.Template,
                Exception = e.GetProperty(KnownProperty.Error)?.ToString(),
             };
 

--- a/src/LogMagic/Writers/WritersConfigurationExtensions.cs
+++ b/src/LogMagic/Writers/WritersConfigurationExtensions.cs
@@ -74,7 +74,6 @@ namespace LogMagic
          return configuration.Custom(new FileLogWriter(fileName, format));
       }
 
-#if NETFULL
       /// <summary>
       /// Writes events to Seq server (https://getseq.net/)
       /// </summary>
@@ -90,6 +89,5 @@ namespace LogMagic
       {
          return configuration.Custom(new SeqWriter(serverAddress, apiKey));
       }
-#endif
    }
 }

--- a/test/LogMagic.Console/Program.cs
+++ b/test/LogMagic.Console/Program.cs
@@ -14,11 +14,9 @@ namespace LogMagic.Console
       {
          L.Config
             .EnrichWith.Constant(KnownProperty.NodeName, "program.cs")
-            //.WriteTo.PoshConsole("{time:H:mm:ss,fff}|{level,-7}|{source}|{" + KnownProperty.NodeName + "}|{stack1}|{stack2}|{message}{error}")
-            //.WriteTo.AzureApplicationInsights("c9e98491-5d78-49f5-9439-bd32e460b44d")
-            .WriteTo.Seq(new Uri("http://localhost:5341"));
+            .WriteTo.PoshConsole("{time:H:mm:ss,fff}|{level,-7}|{source}|{" + KnownProperty.NodeName + "}|{stack1}|{stack2}|{message}{error}")
+            .WriteTo.AzureApplicationInsights("c9e98491-5d78-49f5-9439-bd32e460b44d");
 
-         log.I("Hello {Name}!", "nblumhardt");
          log.D("test");
 
          using (L.CP("stack1", "s11"))

--- a/test/LogMagic.Console/Program.cs
+++ b/test/LogMagic.Console/Program.cs
@@ -14,9 +14,11 @@ namespace LogMagic.Console
       {
          L.Config
             .EnrichWith.Constant(KnownProperty.NodeName, "program.cs")
-            .WriteTo.PoshConsole("{time:H:mm:ss,fff}|{level,-7}|{source}|{" + KnownProperty.NodeName + "}|{stack1}|{stack2}|{message}{error}")
-            .WriteTo.AzureApplicationInsights("c9e98491-5d78-49f5-9439-bd32e460b44d");
+            //.WriteTo.PoshConsole("{time:H:mm:ss,fff}|{level,-7}|{source}|{" + KnownProperty.NodeName + "}|{stack1}|{stack2}|{message}{error}")
+            //.WriteTo.AzureApplicationInsights("c9e98491-5d78-49f5-9439-bd32e460b44d")
+            .WriteTo.Seq(new Uri("http://localhost:5341"));
 
+         log.I("Hello {Name}!", "nblumhardt");
          log.D("test");
 
          using (L.CP("stack1", "s11"))

--- a/test/LogMagic.Test/FormattedStringTest.cs
+++ b/test/LogMagic.Test/FormattedStringTest.cs
@@ -30,5 +30,13 @@ namespace LogMagic.Test
          Assert.Equal(1, fs.NamedParameters["first"]);
          Assert.Equal(2, fs.NamedParameters["second"]);
       }
+
+      [Fact]
+      public void Parse_OriginalFormatIsPreserved()
+      {
+         const string template = "Hello, {name}!";
+         FormattedString fs = FormattedString.Parse(template, new object[]{"Alice"});
+         Assert.Equal(template, fs.Template);
+      }
    }
 }


### PR DESCRIPTION
Resolves #8. Also enables the Seq writer on .NET Core (configuration extension method was excluded).

![image](https://user-images.githubusercontent.com/342712/30187843-c824c926-946e-11e7-88a2-b2771f82477e.png)


The natural name for the property on `FormattedString` would have been `Format`, but that name is already used for the method. I went with `Template` (`Text` may be another option).

A lot of the tests fail on my machine before and after the change (but not the changed code) - guessing there are a few environment-specific dependencies that aren't present for me.